### PR TITLE
Add react-flow setup and basic diagram component

### DIFF
--- a/components/DiagramPanel.tsx
+++ b/components/DiagramPanel.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactFlow from 'react-flow-renderer';
+
+const DiagramPanel: React.FC = () => {
+  return (
+    <div style={{ width: '100%', height: '100%', background: '#f0f0f0' }}>
+      <ReactFlow nodes={[]} edges={[]} />
+    </div>
+  );
+};
+
+export default DiagramPanel;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ai_guru",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "react-flow-renderer": "^11.8.1"
+  }
+}


### PR DESCRIPTION
## Summary
- initialize package.json and add `react-flow-renderer` dependency
- create `DiagramPanel` component that renders an empty `ReactFlow`

## Testing
- `npm install react-flow-renderer` *(fails: EHOSTUNREACH)*