### PR TITLE
Create layout with Chat and Diagram panels

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,15 @@
+import ChatPanel from '../components/ChatPanel';
+import DiagramPanel from '../components/DiagramPanel';
+
+export default function Page() {
+  return (
+    <div className="flex h-screen">
+      <div className="w-2/5 border-r overflow-y-auto">
+        <ChatPanel />
+      </div>
+      <div className="w-3/5 overflow-y-auto">
+        <DiagramPanel />
+      </div>
+    </div>
+  );
+}

--- a/components/DiagramPanel.tsx
+++ b/components/DiagramPanel.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function DiagramPanel() {
+  return (
+    <div className="p-4">
+      {/* TODO: Implement diagram display logic */}
+      <p>Diagram will be rendered here.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add DiagramPanel placeholder
- create Next.js page layout that shows ChatPanel and DiagramPanel side by side

## Testing
- `npm test` *(fails: Could not read package.json)*