### PR TITLE
Remove duplicate phase parameter

### DIFF
--- a/components/ChatPanel.tsx
+++ b/components/ChatPanel.tsx
@@ -48,7 +48,7 @@ export default function ChatPanel() {
     setMessages(prev => [...prev, assistantMessage]);
 
     try {
-      const res = await fetch('/api/ai?phase=parse', {
+      const res = await fetch('/api/ai', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ messages: updatedMessages, phase: 'parse' })


### PR DESCRIPTION
## Summary
- stop passing the `phase` in both query string and body

## Testing
- `npm test` *(fails: Error: no test specified)*