### PR TITLE
Handle diagram updates from context

### DIFF
--- a/components/DiagramContext.tsx
+++ b/components/DiagramContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useState, useRef } from 'react';
 
 export interface DiagramData {
   nodes: any[];
@@ -8,18 +8,32 @@ export interface DiagramData {
 interface DiagramContextValue {
   diagram: DiagramData | null;
   diagramUpdated: (d: DiagramData) => void;
+  subscribe: (cb: (d: DiagramData) => void) => () => void;
 }
 
 const DiagramContext = createContext<DiagramContextValue>({
   diagram: null,
-  diagramUpdated: () => {}
+  diagramUpdated: () => {},
+  subscribe: () => () => {}
 });
 
 export const DiagramProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [diagram, setDiagram] = useState<DiagramData | null>(null);
-  const diagramUpdated = (d: DiagramData) => setDiagram(d);
+  const handlers = useRef<Array<(d: DiagramData) => void>>([]);
+
+  const diagramUpdated = (d: DiagramData) => {
+    setDiagram(d);
+    handlers.current.forEach(h => h(d));
+  };
+
+  const subscribe = (cb: (d: DiagramData) => void) => {
+    handlers.current.push(cb);
+    return () => {
+      handlers.current = handlers.current.filter(h => h !== cb);
+    };
+  };
   return (
-    <DiagramContext.Provider value={{ diagram, diagramUpdated }}>
+    <DiagramContext.Provider value={{ diagram, diagramUpdated, subscribe }}>
       {children}
     </DiagramContext.Provider>
   );

--- a/components/DiagramPanel.tsx
+++ b/components/DiagramPanel.tsx
@@ -1,12 +1,35 @@
-import React from 'react';
-import ReactFlow from 'react-flow-renderer';
+import React, { useEffect } from 'react';
+import ReactFlow, { useNodesState, useEdgesState } from 'react-flow-renderer';
 import { useDiagram } from './DiagramContext';
 
 const DiagramPanel: React.FC = () => {
-  const { diagram } = useDiagram();
+  const { diagram, subscribe } = useDiagram();
+  const [nodes, setNodes, onNodesChange] = useNodesState(diagram?.nodes || []);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(diagram?.edges || []);
+
+  useEffect(() => {
+    if (diagram) {
+      setNodes(diagram.nodes);
+      setEdges(diagram.edges);
+    }
+  }, [diagram, setNodes, setEdges]);
+
+  useEffect(() => {
+    const unsub = subscribe(d => {
+      setNodes(d.nodes);
+      setEdges(d.edges);
+    });
+    return unsub;
+  }, [subscribe, setNodes, setEdges]);
+
   return (
     <div style={{ width: '100%', height: '100%', background: '#f0f0f0' }}>
-      <ReactFlow nodes={diagram?.nodes || []} edges={diagram?.edges || []} />
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add basic subscription API in DiagramContext
- listen to context updates in DiagramPanel and update nodes/edges

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules)*
- `npm run build` *(fails: next not found)*