### PR TITLE
Add Supabase email auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 # Example environment variables
 OPENAI_API_KEY=your-openai-api-key-here
 # Add additional secrets here as needed
+NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,19 +1,49 @@
-import ChatPanel from '../components/ChatPanel';
-import DiagramPanel from '../components/DiagramPanel';
-import { DiagramProvider } from '../components/DiagramContext';
+'use client'
+
+import ChatPanel from '../components/ChatPanel'
+import DiagramPanel from '../components/DiagramPanel'
+import { DiagramProvider } from '../components/DiagramContext'
+import AuthModal from '../components/AuthModal'
+import { useState, useEffect } from 'react'
+import { getSupabaseClient } from '../lib/supabaseClient'
 
 export default function Page() {
+  const supabase = getSupabaseClient()
+  const [showAuth, setShowAuth] = useState(false)
+  const [loggedIn, setLoggedIn] = useState(false)
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      setLoggedIn(!!data.session)
+    })
+    const { data: listener } = supabase.auth.onAuthStateChange((_, session) => {
+      setLoggedIn(!!session)
+    })
+    return () => {
+      listener.subscription.unsubscribe()
+    }
+  }, [supabase])
+
+  const signOut = async () => {
+    await supabase.auth.signOut()
+  }
+
   return (
     <DiagramProvider>
       <div className="flex h-screen">
-        <div className="w-2/5 border-r border-gray-200">
+        <div className="w-2/5 border-r border-gray-200 p-2 space-y-2">
+          <div>
+            {!loggedIn && <button onClick={() => setShowAuth(true)}>Login</button>}
+            {loggedIn && <button onClick={signOut}>Logout</button>}
+          </div>
           <ChatPanel />
         </div>
         <div className="w-3/5">
           <DiagramPanel />
         </div>
       </div>
+      <AuthModal open={showAuth} onClose={() => setShowAuth(false)} />
     </DiagramProvider>
-  );
+  )
 }
 

--- a/components/AuthModal.tsx
+++ b/components/AuthModal.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { useState, FormEvent } from 'react'
+import { getSupabaseClient } from '../lib/supabaseClient'
+
+interface AuthModalProps {
+  open: boolean
+  onClose: () => void
+}
+
+export default function AuthModal({ open, onClose }: AuthModalProps) {
+  const supabase = getSupabaseClient()
+  const [email, setEmail] = useState('')
+  const [message, setMessage] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    setMessage('')
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: { emailRedirectTo: window.location.href }
+    })
+    if (error) {
+      setMessage(error.message)
+    } else {
+      setMessage('Check your email for a login link.')
+    }
+    setLoading(false)
+  }
+
+  if (!open) return null
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center'
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{ background: '#fff', padding: '1rem', width: '300px' }}
+        onClick={e => e.stopPropagation()}
+      >
+        <h2>Sign In</h2>
+        <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+          <input
+            type="email"
+            placeholder="Your email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            required
+          />
+          <button type="submit" disabled={loading}>
+            {loading ? 'Sending...' : 'Send Magic Link'}
+          </button>
+        </form>
+        {message && <p style={{ marginTop: '0.5rem' }}>{message}</p>}
+      </div>
+    </div>
+  )
+}

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,0 +1,13 @@
+'use client'
+
+import { createBrowserSupabaseClient } from '@supabase/auth-helpers-nextjs'
+import { SupabaseClient } from '@supabase/supabase-js'
+
+let client: SupabaseClient | null = null
+
+export function getSupabaseClient() {
+  if (!client) {
+    client = createBrowserSupabaseClient()
+  }
+  return client
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "react-dom": "18.2.0",
     "typescript": "^5.2.2",
     "@types/react": "^18.2.14",
-    "@types/node": "20.8.6"
+    "@types/node": "20.8.6",
+    "@supabase/auth-helpers-nextjs": "^0.7.0",
+    "@supabase/auth-helpers-react": "^0.3.2",
+    "@supabase/supabase-js": "^2.39.5"
   }
 }


### PR DESCRIPTION
## Summary
- integrate `@supabase/auth-helpers-nextjs` and related packages
- provide Supabase URL and anon key env vars
- create a Supabase client helper
- add `AuthModal` component for magic-link login
- add login/logout buttons and modal usage on the main page

## Testing
- `npm test` *(fails: Error: no test specified)*