### PR TITLE
Add demo playback route

### DIFF
--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import DiagramOnly from '../../components/DiagramOnly'
+import OpportunitiesPanel, { Opportunity } from '../../components/OpportunitiesPanel'
+
+interface Message {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+interface DemoData {
+  messages: Message[]
+  nodes: any[]
+  edges: any[]
+  opportunities?: Opportunity[]
+}
+
+export default function DemoPage() {
+  const [messages, setMessages] = useState<Message[]>([])
+  const [diagram, setDiagram] = useState<{ nodes: any[]; edges: any[] }>({ nodes: [], edges: [] })
+  const [opps, setOpps] = useState<Opportunity[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+    fetch('/demo-data.json')
+      .then(res => res.json())
+      .then((data: DemoData) => {
+        async function play() {
+          for (const msg of data.messages || []) {
+            if (cancelled) return
+            setMessages(prev => [...prev, msg])
+            await new Promise(r => setTimeout(r, 150))
+          }
+          if (cancelled) return
+          setDiagram({ nodes: data.nodes || [], edges: data.edges || [] })
+          setOpps(data.opportunities || [])
+        }
+        play()
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return (
+    <div className="flex h-screen">
+      <div className="w-2/5 border-r border-gray-200 p-2 overflow-y-auto">
+        {messages.map((m, i) => (
+          <div key={i} style={{ margin: '0.25rem 0' }}>
+            <strong>{m.role === 'user' ? 'You' : 'Assistant'}:</strong>
+            <div>{m.content}</div>
+          </div>
+        ))}
+      </div>
+      <div className="w-3/5 flex flex-col">
+        <div style={{ flex: 1 }}>
+          <DiagramOnly nodes={diagram.nodes} edges={diagram.edges} />
+        </div>
+        {opps.length > 0 && (
+          <div style={{ borderTop: '1px solid #ccc' }}>
+            <OpportunitiesPanel opportunities={opps} />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/DiagramOnly.tsx
+++ b/components/DiagramOnly.tsx
@@ -1,0 +1,28 @@
+import React, { useEffect } from 'react';
+import ReactFlow, { useNodesState, useEdgesState, Node, Edge } from 'react-flow-renderer';
+
+interface Props {
+  nodes: Node[];
+  edges: Edge[];
+}
+
+const DiagramOnly: React.FC<Props> = ({ nodes, edges }) => {
+  const [rfNodes, setRfNodes, onNodesChange] = useNodesState(nodes);
+  const [rfEdges, setRfEdges, onEdgesChange] = useEdgesState(edges);
+
+  useEffect(() => setRfNodes(nodes), [nodes, setRfNodes]);
+  useEffect(() => setRfEdges(edges), [edges, setRfEdges]);
+
+  return (
+    <div style={{ width: '100%', height: '100%' }}>
+      <ReactFlow
+        nodes={rfNodes}
+        edges={rfEdges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+      />
+    </div>
+  );
+};
+
+export default DiagramOnly;

--- a/public/demo-data.json
+++ b/public/demo-data.json
@@ -1,0 +1,21 @@
+{
+  "messages": [
+    {"role": "user", "content": "Let's outline the onboarding workflow."},
+    {"role": "assistant", "content": "Sure, here is a simple flow."},
+    {"role": "assistant", "content": "```json\n{\n  \"nodes\": [\n    {\"id\": \"1\", \"data\": {\"label\": \"Start\"}, \"position\": {\"x\": 0, \"y\": 0}},\n    {\"id\": \"2\", \"data\": {\"label\": \"Collect Docs\"}, \"position\": {\"x\": 150, \"y\": 0}},\n    {\"id\": \"3\", \"data\": {\"label\": \"Set Up Accounts\"}, \"position\": {\"x\": 300, \"y\": 0}}\n  ],\n  \"edges\": [\n    {\"id\": \"e1-2\", \"source\": \"1\", \"target\": \"2\"},\n    {\"id\": \"e2-3\", \"source\": \"2\", \"target\": \"3\"}\n  ]\n}\n```"},
+    {"role": "user", "content": "Great! What can we improve?"},
+    {"role": "assistant", "content": "1. Automate data entry\nUse a form to gather docs."}
+  ],
+  "nodes": [
+    {"id": "1", "data": {"label": "Start"}, "position": {"x": 0, "y": 0}},
+    {"id": "2", "data": {"label": "Collect Docs"}, "position": {"x": 150, "y": 0}},
+    {"id": "3", "data": {"label": "Set Up Accounts"}, "position": {"x": 300, "y": 0}}
+  ],
+  "edges": [
+    {"id": "e1-2", "source": "1", "target": "2"},
+    {"id": "e2-3", "source": "2", "target": "3"}
+  ],
+  "opportunities": [
+    {"id": "1", "title": "Automate data entry", "description": "Use a form to gather docs."}
+  ]
+}


### PR DESCRIPTION
## Summary
- create demo-data.json fixture in public folder
- add DiagramOnly component for basic diagram rendering
- implement `/demo` page that loads static JSON and replays chat with a 150ms delay

## Testing
- `npm run build` *(fails: next not found)*