### PR TITLE
Fix react flow dependency

### DIFF
--- a/components/DiagramOnly.tsx
+++ b/components/DiagramOnly.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import ReactFlow, { useNodesState, useEdgesState, Node, Edge } from 'react-flow-renderer';
+import ReactFlow, { useNodesState, useEdgesState, Node, Edge } from 'reactflow';
 
 interface Props {
   nodes: Node[];

--- a/components/DiagramPanel.tsx
+++ b/components/DiagramPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import ReactFlow, { useNodesState, useEdgesState } from 'react-flow-renderer';
+import ReactFlow, { useNodesState, useEdgesState } from 'reactflow';
 import { useDiagram } from './DiagramContext';
 import OpportunitiesPanel, { Opportunity } from './OpportunitiesPanel';
 

--- a/lib/diagram.ts
+++ b/lib/diagram.ts
@@ -29,7 +29,7 @@ export interface ReactFlowData {
 
 /**
  * Convert a plain JSON representation of a diagram into
- * the structure expected by react-flow-renderer.
+ * the structure expected by React Flow.
  *
  * The input should conform to the schema described in the PRD:
  *

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "react-flow-renderer": "^11.8.1",
+    "reactflow": "^11.10.7",
     "ai": "^2.1.0",
     "next": "14.1.0",
     "react": "18.2.0",


### PR DESCRIPTION
## Summary
- use `reactflow` package instead of deprecated `react-flow-renderer`
- update imports for new package
- tweak comment about React Flow

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build` *(fails: next not found)*